### PR TITLE
Fix name of zip compression module

### DIFF
--- a/index.html
+++ b/index.html
@@ -546,7 +546,7 @@
             },
             {
               id: "zip",
-              name: "Zip Compression Support",
+              name: "ZIP",
               description:
                 "Required to use the ZIPReader and ZIPPacker classes (also requires Minizip to be enabled).",
               enabled: true,

--- a/index.html
+++ b/index.html
@@ -546,7 +546,7 @@
             },
             {
               id: "zip",
-              name: "WebXR",
+              name: "Zip Compression Support",
               description:
                 "Required to use the ZIPReader and ZIPPacker classes (also requires Minizip to be enabled).",
               enabled: true,


### PR DESCRIPTION
The zip module has the same name as WebXR. This PR changes it to a more correct name. 

Closes #15 