### PR TITLE
Added "Extra Optimize" sub-option for the "Optimize for size" option (and Sub-Option Support)

### DIFF
--- a/index.html
+++ b/index.html
@@ -423,13 +423,6 @@
               default: true,
             },
             {
-              id: "navigation",
-              name: "Navigation",
-              description: "Required to use NavigationServer.",
-              enabled: true,
-              default: true,
-            },
-            {
               id: "noise",
               name: "Noise",
               description:

--- a/index.html
+++ b/index.html
@@ -154,16 +154,15 @@
                 "Extra: Further reduces size (Only for Godot 4.5+)",
               notModule: true,
             },
-            // TODO: Uncomment when Godot 4.3 is released.
-            // {
-            //   id: "threads",
-            //   name: "Enable threading support",
-            //   description:
-            //     "Disabling this removes SharedArrayBuffer and cross-origin isolation requirements for web exports.",
-            //   enabled: true,
-            //   default: true,
-            //   notModule: true,
-            // },
+            {
+              id: "threads",
+              name: "Enable threading support",
+              description:
+                "Disabling this removes SharedArrayBuffer and cross-origin isolation requirements for web exports.",
+              enabled: true,
+              default: true,
+              notModule: true,
+            },
             {
               id: "precision",
               name: "Enable double-precision floats",
@@ -227,16 +226,15 @@
               default: true,
               notModule: true,
             },
-            // TODO: Uncomment when Godot 4.3 is released.
-            // {
-            //   id: "d3d12",
-            //   name: "Enable Direct3D 12",
-            //   description:
-            //     "Required to use Forward+ and Mobile rendering methods with Direct3D 12 (only effective when targeting Windows). If enabled, run `misc/scripts/install_d3d12_sdk_windows.py` in the Godot repository to set up dependencies before compiling.",
-            //   enabled: false,
-            //   default: false,
-            //   notModule: true,
-            // },
+            {
+              id: "d3d12",
+              name: "Enable Direct3D 12",
+              description:
+                "Required to use Forward+ and Mobile rendering methods with Direct3D 12 (only effective when targeting Windows). If enabled, run `misc/scripts/install_d3d12_sdk_windows.py` in the Godot repository to set up dependencies before compiling.",
+              enabled: false,
+              default: false,
+              notModule: true,
+            },
             // "astcenc" isn't included as it's editor-only.
             {
               id: "basis_universal",
@@ -286,15 +284,14 @@
               default: true,
             },
             // "etcpak" isn't included as it's editor-only.
-            // TODO: Uncomment when Godot 4.3 is released.
-            // {
-            //   id: "fbx",
-            //   name: "fbx",
-            //   description:
-            //     "Required to load non-imported 3D scenes in the FBX format.",
-            //   enabled: true,
-            //   default: true,
-            // },
+            {
+              id: "fbx",
+              name: "fbx",
+              description:
+                "Required to load non-imported 3D scenes in the FBX format.",
+              enabled: true,
+              default: true,
+            },
             {
               id: "freetype",
               name: "FreeType",
@@ -333,15 +330,14 @@
               enabled: true,
               default: true,
             },
-            // TODO: Uncomment when Godot 4.3 is released.
-            // {
-            //   id: "interactive_music",
-            //   name: "Interactive music",
-            //   description:
-            //     "Required to use interactive music (AudioStreamInteractive, AudioStreamPlaylist, AudioStreamSynchronized resources).",
-            //   enabled: true,
-            //   default: true,
-            // },
+            {
+              id: "interactive_music",
+              name: "Interactive music",
+              description:
+                "Required to use interactive music (AudioStreamInteractive, AudioStreamPlaylist, AudioStreamSynchronized resources).",
+              enabled: true,
+              default: true,
+            },
             {
               id: "jpg",
               name: "JPG",
@@ -411,11 +407,18 @@
               enabled: true,
               default: true,
             },
+            // "navigation" module is replaced with 2 seprate modules, "navigation_2d" and "navigation_3d" in Godot 4.5
             {
-              id: "multiplayer",
-              name: "Multiplayer",
-              description:
-                "Required to use the multiplayer replication system (RPCs).",
+              id: "navigation_2d",
+              name: "Navigation 2D",
+              description: "Required to use NavigationServer for 2D.",
+              enabled: true,
+              default: true,
+            },
+            {
+              id: "navigation_3d",
+              name: "Navigation 3D",
+              description: "Required to use NavigationServer for 3D.",
               enabled: true,
               default: true,
             },

--- a/index.html
+++ b/index.html
@@ -65,6 +65,18 @@
                 type="text"
                 x-model="option.value"
               />
+              <!-- Sub Option Visuals -->
+              <input 
+                x-show="option.subOptionEnabled != null & option.enabled"
+                type="checkbox" 
+                x-model="option.subOptionEnabled"
+                style="margin-left: 30px; margin-top: 15px;"
+              />
+              <span
+                x-show="option.subDescription != null & option.enabled"
+                x-text="option.subDescription"
+              >
+              </span>
             </label>
           </template>
         </div>
@@ -137,6 +149,9 @@
                 "Optimize the compiled binary for size instead of speed.",
               enabled: false,
               default: false,
+              subOptionEnabled: false,
+              subDescription:
+                "Extra: Further reduces size (Only for Godot 4.5+)",
               notModule: true,
             },
             // TODO: Uncomment when Godot 4.3 is released.
@@ -581,7 +596,7 @@
               } else if (option.enabled !== option.default) {
                 if (option.notModule != undefined) {
                   if (option.id === "optimize") {
-                    generated += `${option.id} = "${option.enabled ? "size" : "speed"}"\n`;
+                    generated += `${option.id} = "${option.enabled ? (option.subOptionEnabled ? "size_extra" : "size") : "speed"}"\n`;
                   } else if (option.id === "precision") {
                     generated += `${option.id} = "${option.enabled ? "double" : "single"}"\n`;
                   } else {


### PR DESCRIPTION
Added support for sub-options,
and made a sub-option for the new **extra optimization** feature. (Introduced in Godot 4.5)

Here's how it currently looks like:
<img width="650" alt="Screenshot-1" src="https://github.com/user-attachments/assets/779a1fc9-8367-4e35-b1c9-8193428d6d7f" />

The sub-option only shows if the main/root option is enabled.
This works for any other option/module box as long as they have these 2 properties.
```
subOptionEnabled: false,
subDescription: "hello"
```

Let me know if anything should be changed! [: