### PR TITLE
Added "Extra Optimize" sub-option for the "Optimize for size" option (and Sub-Option Support)

### DIFF
--- a/index.html
+++ b/index.html
@@ -65,6 +65,18 @@
                 type="text"
                 x-model="option.value"
               />
+              <!-- Sub Option Visuals -->
+              <input 
+                x-show="option.subOptionEnabled != null & option.enabled"
+                type="checkbox" 
+                x-model="option.subOptionEnabled"
+                style="margin-left: 30px; margin-top: 15px;"
+              />
+              <span
+                x-show="option.subDescription != null & option.enabled"
+                x-text="option.subDescription"
+              >
+              </span>
             </label>
           </template>
         </div>
@@ -137,6 +149,9 @@
                 "Optimize the compiled binary for size instead of speed.",
               enabled: false,
               default: false,
+              subOptionEnabled: false,
+              subDescription:
+                "Extra: Further reduces size (Only for Godot 4.5+)",
               notModule: true,
             },
             // TODO: Uncomment when Godot 4.3 is released.
@@ -581,7 +596,7 @@
               } else if (option.enabled !== option.default) {
                 if (option.notModule != undefined) {
                   if (option.id === "optimize") {
-                    generated += `${option.id} = "${option.enabled ? "size" : "speed"}"\n`;
+                    generated += `${option.id} = "${option.enabled ? (option.subOptionEnabled ? "size_extra" : "size") : "speed"}"\n`;
                   } else if (option.id === "precision") {
                     generated += `${option.id} = "${option.enabled ? "double" : "single"}"\n`;
                   } else {

--- a/index.html
+++ b/index.html
@@ -151,7 +151,7 @@
               default: false,
               subOptionEnabled: false,
               subDescription:
-                "Extra: Further reduces size (Only for Godot 4.5+)",
+                "Extra: Further reduces size with a greater performance cost (requires Godot 4.5+)",
               notModule: true,
             },
             // TODO: Uncomment when Godot 4.3 is released.

--- a/index.html
+++ b/index.html
@@ -65,7 +65,7 @@
                 type="text"
                 x-model="option.value"
               />
-              <!-- Sub Option Visuals -->
+              <!-- Sub-option visuals -->
               <input 
                 x-show="option.subOptionEnabled != null & option.enabled"
                 type="checkbox" 


### PR DESCRIPTION
Added support for sub-options,
and made a sub-option for the new **extra optimization** feature. (Introduced in Godot 4.5)

Here's how it currently looks like:
<img width="650" alt="Screenshot-1" src="https://github.com/user-attachments/assets/779a1fc9-8367-4e35-b1c9-8193428d6d7f" />

The sub-option only shows if the main/root option is enabled.
This works for any other option/module box as long as they have these 2 properties.
```
subOptionEnabled: false,
subDescription: "hello"
```

Let me know if anything should be changed! [: